### PR TITLE
Added unittests to the test file

### DIFF
--- a/commontests/character.json
+++ b/commontests/character.json
@@ -1,0 +1,13 @@
+[
+    {
+        "old": "The quick brown fox.",
+        "new": "The kuick brown fix.",
+        "diff": [["=", "The "],
+                 ["-", "q"],
+                 ["+", "k"],
+                 ["=", "uick brown f"],
+                 ["-", "o"],
+                 ["+", "i"],
+                 ["=", "x."]]
+    }
+]

--- a/python/test.py
+++ b/python/test.py
@@ -1,8 +1,140 @@
-
 from doctest import testmod, testfile
+import unittest
 import simplediff
 
-if __name__ == '__main__':
-    testmod(simplediff)
-    testfile('README.md')
 
+class DiffTests(unittest.TestCase):
+    def test_delete_diff(self):
+        strings = TESTS['delete']
+        for check in strings:
+            self.assertEqual(simplediff.diff(check['old'], check['new']),
+                             check['diff'])
+
+    def test_insert_diff(self):
+        strings = TESTS['insert']
+        for check in strings:
+            self.assertEqual(simplediff.diff(check['old'], check['new']),
+                             check['diff'])
+
+    def test_words_diff(self):
+        strings = TESTS['words']
+        for check in strings:
+            self.assertEqual(simplediff.diff(check['old'], check['new']),
+                             check['diff'])
+
+    def test_character_diff(self):
+        strings = TESTS['character']
+
+        for check in strings:
+            self.assertEqual(simplediff.diff(check['old'], check['new']),
+                             check['diff'])
+
+    def test_doctests(self):
+        testmod(simplediff)
+        testfile('README.md')
+
+if __name__ == '__main__':
+
+    # Checks
+    TESTS = {
+        'insert': [
+            {
+                "old": [1, 3, 4],
+                "new": [1, 2, 3, 4],
+                "diff": [("=", [1]),
+                         ("+", [2]),
+                         ("=", [3, 4])]
+            },
+            {
+                "old": [1, 2, 3, 8, 9, 12, 13],
+                "new": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                "diff": [("=", [1, 2, 3]),
+                         ("+", [4, 5, 6, 7]),
+                         ("=", [8, 9]),
+                         ("+", [10, 11]),
+                         ("=", [12, 13]),
+                         ("+", [14, 15])]
+            },
+            {
+                "old": [1, 2, 3, 4, 5],
+                "new": [1, 2, 2, 3, 4, 5],
+                "diff": [("=", [1]),
+                         ("+", [2]),
+                         ("=", [2, 3, 4, 5])]
+            },
+            {
+                "old": [1, 2, 3, 4, 5],
+                "new": [1, 2, 2, 3, 4, 4, 5],
+                "diff": [("=", [1]),
+                         ("+", [2]),
+                         ("=", [2, 3, 4]),
+                         ("+", [4]),
+                         ("=", [5])]
+            },
+            {
+                "old": [1, 2, 3, 4, 5],
+                "new": [1, 2, 1, 2, 3, 3, 2, 1, 4, 5],
+                "diff": [("+", [1, 2]),
+                         ("=", [1, 2, 3]),
+                         ("+", [3, 2, 1]),
+                         ("=", [4, 5])]
+            }
+        ],
+        'delete': [
+            {
+                "old": [1, 2, 3, 4, 5],
+                "new": [1, 2, 5],
+                "diff": [("=", [1, 2]),
+                         ("-", [3, 4]),
+                         ("=", [5])]
+            },
+            {
+                "old": [1, 2, 3, 4, 5, 6, 7, 8],
+                "new": [3, 6, 7],
+                "diff": [("-", [1, 2]),
+                         ("=", [3]),
+                         ("-", [4, 5]),
+                         ("=", [6, 7]),
+                         ("-", [8])]
+            },
+            {
+                "old": [1, 2, 3, 4, 5, 1, 2, 3, 4, 5],
+                "new": [1, 2, 3, 4, 5],
+                "diff": [("=", [1, 2, 3, 4, 5]),
+                         ("-", [1, 2, 3, 4, 5])]
+            }
+        ],
+        'words': [
+            {
+                "old": ["The", "quick", "brown", "fox"],
+                "new": ["The", "slow", "green", "turtle"],
+                "diff": [("=", ["The"]),
+                         ("-", ["quick", "brown", "fox"]),
+                         ("+", ["slow", "green", "turtle"])]
+            },
+            {
+                "old": ["jumps", "over", "the", "lazy", "dog"],
+                "new": ["walks", "around", "the", "orange", "cat"],
+                "diff": [("-", ["jumps", "over"]),
+                         ("+", ["walks", "around"]),
+                         ("=", ["the"]),
+                         ("-", ["lazy", "dog"]),
+                         ("+", ["orange", "cat"])]
+            }
+        ],
+        'character': [
+            {
+                "old": "The quick brown fox.",
+                "new": "The kuick brown fix.",
+                "diff": [("=", "The "),
+                         ("-", "q"),
+                         ("+", "k"),
+                         ("=", "uick brown f"),
+                         ("-", "o"),
+                         ("+", "i"),
+                         ("=", "x.")]
+            }
+        ]
+    }
+
+    unittest.main()


### PR DESCRIPTION
Added `character.json` to components folder.
Added unittests to `test.py` file:

The reason I used an array inside the file is because:
- Reading json lose the tuples so I can't do assertEqual
- Using `json.dumps()` in both vars is dirty.
- Some people **may** edit the package directly from PyPi and they don't have the json files.

I've added your doctests inside the unittests.

```
Going-Merry:python fmartingr$ pwd
/Users/fmartingr/Developer/simplediff/python
Going-Merry:python fmartingr$ python test.py
.....
----------------------------------------------------------------------
Ran 5 tests in 0.009s

OK
```
