### PR TITLE
Update simplediff.php

### DIFF
--- a/php/simplediff.php
+++ b/php/simplediff.php
@@ -42,7 +42,7 @@ function diff($old, $new){
 
 function htmlDiff($old, $new){
 	$ret = '';
-	$diff = diff(explode(' ', $old), explode(' ', $new));
+	$diff = $this->_diff(preg_split("/[\s,]+/", $old), preg_split("/[\s,]+/", $new));
 	foreach($diff as $k){
 		if(is_array($k))
 			$ret .= (!empty($k['d'])?"<del>".implode(' ',$k['d'])."</del> ":'').


### PR DESCRIPTION
The following change fixes a small bug where if you have text on line 1 an empty line 2 and something else on line 3 and in the new text, you insert something into line 2, it will highlight the last word of line 1 and the first word of line 3 as being deletions. This should be merged into the Master branch I think

For example:
## Old text

This is line one.

This is line three.
## New text

This is line one.
Something is now here in line two
This is line three.
### 

The only thing that should be highlighted is line 2 being an insert.
